### PR TITLE
Add playlist scraping and analysis modules

### DIFF
--- a/playlistgen/__init__.py
+++ b/playlistgen/__init__.py
@@ -1,0 +1,29 @@
+"""PlaylistGen package."""
+
+from .playlist_scraper import (
+    fetch_spotify_playlists,
+    fetch_youtube_playlists,
+    fetch_apple_music_playlists,
+)
+from .pattern_analyzer import (
+    analyze_playlists,
+    vectorize_playlists,
+    vectorize_playlist,
+)
+from .playlist_generator import generate_candidates
+from .similarity import score_playlists
+from .feedback import load_feedback, save_feedback, update_feedback
+
+__all__ = [
+    "fetch_spotify_playlists",
+    "fetch_youtube_playlists",
+    "fetch_apple_music_playlists",
+    "analyze_playlists",
+    "vectorize_playlists",
+    "vectorize_playlist",
+    "generate_candidates",
+    "score_playlists",
+    "load_feedback",
+    "save_feedback",
+    "update_feedback",
+]

--- a/playlistgen/feedback.py
+++ b/playlistgen/feedback.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+from typing import Dict
+
+
+def load_feedback(path: str) -> Dict:
+    p = Path(path)
+    if p.exists():
+        with open(p, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def save_feedback(path: str, data: Dict) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def update_feedback(path: str, playlist_name: str, action: str) -> None:
+    data = load_feedback(path)
+    actions = data.setdefault(playlist_name, [])
+    actions.append(action)
+    save_feedback(path, data)

--- a/playlistgen/pattern_analyzer.py
+++ b/playlistgen/pattern_analyzer.py
@@ -1,0 +1,58 @@
+import logging
+from typing import List, Dict, Tuple, Optional
+
+import pandas as pd
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.cluster import KMeans
+
+
+def _playlist_text(df: pd.DataFrame) -> List[str]:
+    return (
+        df.get("Genre", "").fillna("").astype(str)
+        + " "
+        + df.get("Mood", "").fillna("").astype(str)
+    ).tolist()
+
+
+def vectorize_playlists(
+    playlists: List[pd.DataFrame],
+    vectorizer: Optional[TfidfVectorizer] = None,
+) -> Tuple[np.ndarray, TfidfVectorizer]:
+    """Vectorize multiple playlists with a shared TF-IDF vectorizer."""
+    texts = [" ".join(_playlist_text(p)) for p in playlists]
+    if vectorizer is None:
+        vectorizer = TfidfVectorizer()
+        X = vectorizer.fit_transform(texts)
+    else:
+        X = vectorizer.transform(texts)
+    return np.asarray(X.todense()), vectorizer
+
+
+def vectorize_playlist(df: pd.DataFrame, vectorizer: Optional[TfidfVectorizer] = None) -> np.ndarray:
+    """Vectorize a single playlist using the provided TF-IDF vectorizer."""
+    if df.empty:
+        return np.zeros(1)
+    text = " ".join(_playlist_text(df))
+    if vectorizer is None:
+        vectorizer = TfidfVectorizer()
+        X = vectorizer.fit_transform([text])
+    else:
+        X = vectorizer.transform([text])
+    return np.asarray(X.todense()).ravel()
+
+
+def analyze_playlists(playlists: List[pd.DataFrame], n_clusters: int = 5) -> Dict:
+    """Cluster playlists to find common patterns.
+
+    Returns a dictionary with the trained model, cluster labels, and vectors.
+    """
+    if not playlists:
+        logging.warning("No playlists provided for analysis")
+        return {}
+
+    X, vectorizer = vectorize_playlists(playlists)
+    k = min(n_clusters, len(playlists))
+    model = KMeans(n_clusters=k, random_state=42)
+    labels = model.fit_predict(X)
+    return {"model": model, "labels": labels, "vectors": X, "vectorizer": vectorizer}

--- a/playlistgen/playlist_generator.py
+++ b/playlistgen/playlist_generator.py
@@ -1,0 +1,28 @@
+import logging
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+from .scoring import score_tracks
+from .clustering import cluster_tracks
+
+
+def generate_candidates(
+    itunes_df: pd.DataFrame,
+    profile: Optional[Dict] = None,
+    preferences: Optional[Dict] = None,
+) -> List[pd.DataFrame]:
+    """Generate playlist candidates from the user's library."""
+    logging.info("Generating candidate playlists")
+    scored = score_tracks(itunes_df, config=profile or {})
+
+    prefs = preferences or {}
+    if "genres" in prefs:
+        genres = [g.lower() for g in prefs["genres"]]
+        scored = scored[scored["Genre"].str.lower().isin(genres)]
+    if "moods" in prefs:
+        scored = scored[scored["Mood"].isin(prefs["moods"])]
+
+    n_clusters = prefs.get("clusters", 5)
+    clusters = cluster_tracks(scored, n_clusters=n_clusters)
+    return clusters

--- a/playlistgen/playlist_scraper.py
+++ b/playlistgen/playlist_scraper.py
@@ -1,0 +1,63 @@
+import os
+import logging
+from typing import List, Optional
+import pandas as pd
+
+try:
+    import spotipy
+    from spotipy.oauth2 import SpotifyClientCredentials
+except ImportError:  # pragma: no cover - spotipy is optional for tests
+    spotipy = None
+
+
+def _get_spotify_client(client_id: Optional[str] = None, client_secret: Optional[str] = None):
+    """Return an authenticated spotipy client or None if credentials are missing."""
+    if spotipy is None:
+        logging.warning("spotipy not installed; cannot fetch Spotify playlists")
+        return None
+    cid = client_id or os.getenv("SPOTIFY_CLIENT_ID")
+    secret = client_secret or os.getenv("SPOTIFY_CLIENT_SECRET")
+    if not cid or not secret:
+        logging.warning("Spotify credentials not configured; skipping playlist fetch")
+        return None
+    auth = SpotifyClientCredentials(client_id=cid, client_secret=secret)
+    return spotipy.Spotify(auth_manager=auth)
+
+
+def fetch_spotify_playlists(query: str, limit: int = 5, client_id: Optional[str] = None, client_secret: Optional[str] = None) -> List[pd.DataFrame]:
+    """Search Spotify for playlists matching the query and return track DataFrames."""
+    sp = _get_spotify_client(client_id, client_secret)
+    if sp is None:
+        return []
+    res = sp.search(q=query, type="playlist", limit=limit)
+    playlists = []
+    for item in res.get("playlists", {}).get("items", []):
+        pid = item.get("id")
+        tracks = sp.playlist_items(pid)
+        rows = []
+        for t in tracks.get("items", []):
+            tr = t.get("track")
+            if not tr:
+                continue
+            rows.append({
+                "Title": tr.get("name"),
+                "Artist": ", ".join(a.get("name") for a in tr.get("artists", [])),
+                "Album": tr.get("album", {}).get("name"),
+                "Genre": None,  # Spotify API does not expose genre at track level
+                "Mood": None,
+                "Year": str(tr.get("album", {}).get("release_date", ""))[:4],
+            })
+        playlists.append(pd.DataFrame(rows))
+    return playlists
+
+
+def fetch_youtube_playlists(*_args, **_kwargs) -> List[pd.DataFrame]:
+    """Placeholder for YouTube Music scraping."""
+    logging.info("YouTube Music scraping is not implemented in this example")
+    return []
+
+
+def fetch_apple_music_playlists(*_args, **_kwargs) -> List[pd.DataFrame]:
+    """Placeholder for Apple Music scraping."""
+    logging.info("Apple Music scraping is not implemented in this example")
+    return []

--- a/playlistgen/similarity.py
+++ b/playlistgen/similarity.py
@@ -1,0 +1,46 @@
+from typing import List, Optional
+import pandas as pd
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+
+def build_vectorizer(playlists: List[pd.DataFrame]) -> TfidfVectorizer:
+    texts = [
+        " ".join((p.get("Genre", "").fillna("") + " " + p.get("Mood", "").fillna(" ")).tolist())
+        for p in playlists
+    ]
+    vectorizer = TfidfVectorizer()
+    vectorizer.fit(texts)
+    return vectorizer
+
+
+def playlist_vector(df: pd.DataFrame, vectorizer: Optional[TfidfVectorizer] = None) -> np.ndarray:
+    text = " ".join(
+        (df.get("Genre", "").fillna("") + " " + df.get("Mood", "").fillna("")).tolist()
+    )
+    if not text:
+        return np.zeros(1)
+    if vectorizer is None:
+        vectorizer = TfidfVectorizer()
+        X = vectorizer.fit_transform([text])
+    else:
+        X = vectorizer.transform([text])
+    return np.asarray(X.todense()).ravel()
+
+
+def score_playlists(
+    candidates: List[pd.DataFrame],
+    benchmark_vecs: List[np.ndarray],
+    vectorizer: Optional[TfidfVectorizer] = None,
+) -> List[float]:
+    if vectorizer is None and benchmark_vecs:
+        # assume benchmark vectors were generated with their own vectorizer
+        vectorizer = TfidfVectorizer()
+    candidate_vecs = [playlist_vector(c, vectorizer) for c in candidates]
+    if not candidate_vecs or not benchmark_vecs:
+        return [0.0 for _ in candidate_vecs]
+    X = np.vstack(candidate_vecs)
+    Y = np.vstack(benchmark_vecs)
+    sims = cosine_similarity(X, Y).max(axis=1)
+    return sims.tolist()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ PyYAML = "^5.1"
 requests = "^2.0"
 tqdm = "^4.0"
 scikit-learn = "^0.24"
+spotipy = "^2.23"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ PyYAML>=5.1
 requests>=2.0
 tqdm>=4.0
 scikit-learn>=0.24
+spotipy>=2.23
 
 # Testing dependencies
 pytest>=6.0

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -1,0 +1,12 @@
+import pandas as pd
+from playlistgen import analyze_playlists, score_playlists, vectorize_playlists
+
+
+def test_analyze_and_score():
+    p1 = pd.DataFrame({"Genre": ["Rock", "Rock"], "Mood": ["Happy", "Happy"]})
+    p2 = pd.DataFrame({"Genre": ["Pop"], "Mood": ["Chill"]})
+    patterns = analyze_playlists([p1, p2], n_clusters=2)
+    assert "labels" in patterns
+    bench_vecs, vec = vectorize_playlists([p1])
+    scores = score_playlists([p1, p2], [bench_vecs[0]], vectorizer=vec)
+    assert len(scores) == 2


### PR DESCRIPTION
## Summary
- add scraping helpers to pull playlists from Spotify with spotipy
- analyze scraped playlists via TF-IDF vectors and k-means
- generate playlist candidates from iTunes library with preference filters
- compute playlist similarity with cosine similarity
- add a simple feedback store
- expose new utilities in package init
- improve vectorization functions for consistent clustering
- add tests for new modules

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f797a53f08333b8870deecce317bb