### PR TITLE
Add library-dir flag for manual music libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A command-line Python tool for generating smart, mood-aware, Daily-Mix style pla
 * 🧩 **Fallback back-fill logic to meet playlist length**
 * 📂 **M3U playlist generation with intelligent naming**
 * 💿 **Optional Year-based mix generation**
+* 📁 **Manual library scanning with `--library-dir` flag**
 
 ---
 
@@ -33,6 +34,8 @@ A command-line Python tool for generating smart, mood-aware, Daily-Mix style pla
 1. Open iTunes (or Music app on macOS).
 2. Go to `File` → `Library` → `Export Library`.
 3. Save the exported XML file (e.g., `iTunes Music Library.xml`) in the root folder.
+
+If you manage your music files manually and don't use iTunes, skip the steps above and run the tool with `--library-dir /path/to/music`.
 
 ### Export your Spotify History
 
@@ -59,6 +62,7 @@ Main options:
 * `--log-level`: Set log level (DEBUG, INFO, etc)
 * `--genre`: Filter mix to only tracks matching the given genre
 * `--mood`: Filter mix to only tracks matching the given mood
+* `--library-dir`: Scan a manual music directory instead of an iTunes library
 
 Example:
 

--- a/playlistgen/cli.py
+++ b/playlistgen/cli.py
@@ -30,6 +30,10 @@ def main():
     parser.add_argument(
         "--mood", help="Filter mix to only tracks matching the given mood"
     )
+    parser.add_argument(
+        "--library-dir",
+        help="Path to a manual music library directory (used if no iTunes library)",
+    )
     subparsers = parser.add_subparsers(dest="command")
 
     subparsers.add_parser("recache-moods", help="Force re-cache all moods from Last.fm")
@@ -53,7 +57,9 @@ def main():
 
         ensure_tag_mood_cache(cfg, itunes_json)
     else:
-        run_pipeline(cfg, genre=args.genre, mood=args.mood)
+        run_pipeline(
+            cfg, genre=args.genre, mood=args.mood, library_dir=args.library_dir
+        )
 
 
 if __name__ == "__main__":

--- a/playlistgen/itunes.py
+++ b/playlistgen/itunes.py
@@ -83,3 +83,47 @@ def load_itunes_json(path: str) -> pd.DataFrame:
             df[num] = pd.to_numeric(df[num], errors="coerce").fillna(0).astype(int)
 
     return df
+
+
+AUDIO_EXTS = {".mp3", ".m4a", ".flac", ".ogg", ".wav", ".aac", ".wma"}
+
+
+def build_library_from_dir(directory: str) -> pd.DataFrame:
+    """Recursively scan a directory for audio files and build a simple library."""
+    dir_path = Path(directory)
+    if not dir_path.exists():
+        raise FileNotFoundError(f"Library directory not found: {directory}")
+
+    records = []
+    for file in dir_path.rglob("*"):
+        if file.suffix.lower() in AUDIO_EXTS:
+            name = file.stem
+            artist = "Unknown"
+            if " - " in name:
+                parts = name.split(" - ", 1)
+                if parts[0].strip():
+                    artist = parts[0].strip()
+                name = parts[1].strip()
+            records.append(
+                {
+                    "Name": name,
+                    "Artist": artist,
+                    "Genre": "",
+                    "Location": str(file.resolve()),
+                    "Play Count": 0,
+                    "Skip Count": 0,
+                }
+            )
+
+    df = pd.DataFrame(records)
+    if not df.empty:
+        df.dropna(subset=["Name", "Artist"], inplace=True)
+    return df
+
+
+def save_itunes_json(df: pd.DataFrame, path: str) -> None:
+    """Save DataFrame in the slim iTunes JSON format."""
+    data = {"tracks": df.to_dict(orient="records")}
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## Summary
- allow scanning a manual library directory with `--library-dir`
- write scanned library to JSON and reuse tagging + clustering pipeline
- document the new flag in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f7f019b648333b527439d7fd36946