### PR TITLE
Add interactive CLI GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ python -m playlistgen --mood "Epic"
 python -m playlistgen --genre "Rap" --mood "Energetic"
 ```
 
+Generate a mix from a seed song using Last.fm similarity:
+
+```bash
+python -m playlistgen seed-song --song "Miles Davis - Blue In Green" --num 20
+```
+
+Launch the interactive text UI:
+
+```bash
+python -m playlistgen gui
+```
+
 ---
 
 ## 🔧 Configuration

--- a/playlistgen/__init__.py
+++ b/playlistgen/__init__.py
@@ -16,6 +16,8 @@ from .playlist_generator import generate_candidates
 from .similarity import score_playlists
 from .feedback import load_feedback, save_feedback, update_feedback
 from .train_model import train_cluster_model
+from .seed_playlist import build_seed_playlist
+from .gui import run_gui
 
 __all__ = [
     "fetch_spotify_playlists",
@@ -30,4 +32,6 @@ __all__ = [
     "load_feedback",
     "save_feedback",
     "update_feedback",
+    "build_seed_playlist",
+    "run_gui",
 ]

--- a/playlistgen/cli.py
+++ b/playlistgen/cli.py
@@ -38,6 +38,14 @@ def main():
 
     subparsers.add_parser("recache-moods", help="Force re-cache all moods from Last.fm")
 
+    subparsers.add_parser("gui", help="Launch interactive TUI")
+
+    seed_parser = subparsers.add_parser(
+        "seed-song", help="Generate a playlist from a seed song"
+    )
+    seed_parser.add_argument("--song", required=True, help="Seed song as 'Artist - Title'")
+    seed_parser.add_argument("--num", type=int, default=20, help="Number of tracks in the mix")
+
     args = parser.parse_args()
     cfg = load_config()
 
@@ -56,6 +64,16 @@ def main():
             cache_db.unlink()
 
         ensure_tag_mood_cache(cfg, itunes_json)
+    elif args.command == "gui":
+        from .gui import run_gui
+
+        run_gui()
+    elif args.command == "seed-song":
+        from .seed_playlist import build_seed_playlist
+
+        build_seed_playlist(
+            args.song, cfg=cfg, library_dir=args.library_dir, limit=args.num
+        )
     else:
         run_pipeline(
             cfg, genre=args.genre, mood=args.mood, library_dir=args.library_dir

--- a/playlistgen/gui.py
+++ b/playlistgen/gui.py
@@ -1,0 +1,40 @@
+"""Interactive CLI-based GUI using questionary."""
+
+import questionary
+
+from .config import load_config
+from .pipeline import run_pipeline
+from .seed_playlist import build_seed_playlist
+
+
+def run_gui():
+    """Launch an interactive text UI."""
+    cfg = load_config()
+    action = questionary.select(
+        "Select an action",
+        choices=[
+            "Generate mix",
+            "Generate from seed song",
+            "Recache moods",
+            "Exit",
+        ],
+    ).ask()
+
+    if action == "Generate mix":
+        genre = questionary.text(
+            "Genre filter (leave blank for none)"
+        ).ask()
+        mood = questionary.text(
+            "Mood filter (leave blank for none)"
+        ).ask()
+        run_pipeline(cfg, genre=genre or None, mood=mood or None)
+    elif action == "Generate from seed song":
+        song = questionary.text("Seed song 'Artist - Title'").ask()
+        num = questionary.text("Number of tracks", default="20").ask()
+        build_seed_playlist(song, cfg=cfg, limit=int(num))
+    elif action == "Recache moods":
+        from .pipeline import ensure_itunes_json, ensure_tag_mood_cache
+
+        itunes_json = ensure_itunes_json(cfg)
+        ensure_tag_mood_cache(cfg, itunes_json)
+    return action

--- a/playlistgen/seed_playlist.py
+++ b/playlistgen/seed_playlist.py
@@ -1,0 +1,123 @@
+# Utilities for generating playlists from a seed song using Last.fm similarity
+import logging
+from typing import List, Tuple, Optional
+
+import pandas as pd
+
+from .config import load_config
+from .itunes import load_itunes_json, build_library_from_dir
+from .scoring import score_tracks
+from .tag_mood_service import load_tag_mood_db
+from .playlist_builder import build_playlists
+from .spotify_profile import load_profile
+
+try:
+    import requests
+except ImportError:  # pragma: no cover - requests is required in runtime
+    requests = None
+
+
+def fetch_similar_tracks(
+    artist: str, track: str, api_key: str, limit: int = 20
+) -> List[Tuple[str, str]]:
+    """Return a list of (artist, track) tuples similar to the given song."""
+    if not requests:
+        raise RuntimeError("The requests package is required")
+    url = (
+        "https://ws.audioscrobbler.com/2.0/?method=track.getsimilar"
+        f"&artist={requests.utils.quote(artist)}"
+        f"&track={requests.utils.quote(track)}"
+        f"&api_key={api_key}&format=json&limit={limit}"
+    )
+    logging.info("Fetching similar tracks from Last.fm")
+    try:
+        resp = requests.get(url, timeout=5)
+        resp.raise_for_status()
+        data = resp.json()
+        tracks = []
+        for t in data.get("similartracks", {}).get("track", []):
+            a = t.get("artist", {}).get("name")
+            n = t.get("name")
+            if a and n:
+                tracks.append((a, n))
+        return tracks
+    except Exception:
+        logging.exception("Failed to fetch similar tracks")
+        return []
+
+
+def generate_seed_playlist(
+    artist: str,
+    track: str,
+    library_df: pd.DataFrame,
+    profile: Optional[dict] = None,
+    tag_mood_db: Optional[dict] = None,
+    limit: int = 20,
+) -> pd.DataFrame:
+    """Generate a playlist seeded from the given song limited to the library."""
+    cfg = load_config()
+    api_key = cfg.get("LASTFM_API_KEY")
+    similar = fetch_similar_tracks(artist, track, api_key, limit=limit * 2)
+
+    matches = []
+    for a, n in similar:
+        mask = (
+            library_df["Artist"].str.lower() == a.lower()
+        ) & (library_df["Name"].str.lower() == n.lower())
+        rows = library_df[mask]
+        if not rows.empty:
+            matches.append(rows.iloc[0])
+        if len(matches) >= limit:
+            break
+
+    if not matches:
+        logging.warning("No similar tracks found in library")
+        return pd.DataFrame()
+
+    df = pd.DataFrame(matches)
+    scored = score_tracks(df, config=profile or {}, tag_mood_db=tag_mood_db)
+    scored = scored.sort_values("Score", ascending=False).head(limit)
+    scored = scored.drop_duplicates(subset=["Artist", "Name"]).reset_index(drop=True)
+    return scored
+
+
+def build_seed_playlist(
+    song: str,
+    cfg: Optional[dict] = None,
+    library_dir: str = None,
+    limit: int = 20,
+):
+    """High level helper used by the CLI."""
+    if cfg is None:
+        cfg = load_config()
+    if " - " in song:
+        artist, track = [s.strip() for s in song.split(" - ", 1)]
+    else:
+        parts = song.split()
+        artist, track = parts[0], " ".join(parts[1:])
+
+    if library_dir:
+        library_df = build_library_from_dir(library_dir)
+    else:
+        from .pipeline import ensure_itunes_json
+
+        itunes_json = ensure_itunes_json(cfg)
+        library_df = load_itunes_json(str(itunes_json))
+
+    tag_db = load_tag_mood_db(cfg.get("TAG_MOOD_CACHE"))
+    profile = load_profile(cfg.get("PROFILE_PATH"))
+
+    playlist_df = generate_seed_playlist(
+        artist,
+        track,
+        library_df,
+        profile=profile,
+        tag_mood_db=tag_db,
+        limit=limit,
+    )
+    if playlist_df.empty:
+        return None
+
+    label = f"Seed Mix - {artist} - {track}"
+    build_playlists([playlist_df], library_df, tracks_per_mix=limit, name_fn=lambda *_: label)
+    return playlist_df

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requests = "^2.0"
 tqdm = "^4.0"
 scikit-learn = "^0.24"
 spotipy = "^2.23"
+questionary = "^1.10"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ requests>=2.0
 tqdm>=4.0
 scikit-learn>=0.24
 spotipy>=2.23
+questionary>=1.10
 
 # Testing dependencies
 pytest>=6.0

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,61 @@
+import playlistgen.gui as gui
+
+
+def test_run_gui_generate_mix(monkeypatch):
+    answers = iter(["Generate mix", "", ""])
+
+    def fake_select(*args, **kwargs):
+        class Q:
+            def ask(self):
+                return next(answers)
+        return Q()
+
+    def fake_text(*args, **kwargs):
+        class Q:
+            def ask(self):
+                return next(answers)
+        return Q()
+
+    called = {}
+    def fake_run_pipeline(cfg, genre=None, mood=None, library_dir=None):
+        called["genre"] = genre
+        called["mood"] = mood
+
+    monkeypatch.setattr(gui.questionary, "select", fake_select)
+    monkeypatch.setattr(gui.questionary, "text", fake_text)
+    monkeypatch.setattr(gui, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(gui, "load_config", lambda: {})
+
+    action = gui.run_gui()
+    assert action == "Generate mix"
+    assert called == {"genre": None, "mood": None}
+
+
+def test_run_gui_seed_song(monkeypatch):
+    answers = iter(["Generate from seed song", "Artist - Title", "5"])
+
+    def fake_select(*args, **kwargs):
+        class Q:
+            def ask(self):
+                return next(answers)
+        return Q()
+
+    def fake_text(*args, **kwargs):
+        class Q:
+            def ask(self):
+                return next(answers)
+        return Q()
+
+    called = {}
+    def fake_build(song, cfg=None, library_dir=None, limit=20):
+        called["song"] = song
+        called["limit"] = limit
+
+    monkeypatch.setattr(gui.questionary, "select", fake_select)
+    monkeypatch.setattr(gui.questionary, "text", fake_text)
+    monkeypatch.setattr(gui, "build_seed_playlist", fake_build)
+    monkeypatch.setattr(gui, "load_config", lambda: {})
+
+    action = gui.run_gui()
+    assert action == "Generate from seed song"
+    assert called == {"song": "Artist - Title", "limit": 5}


### PR DESCRIPTION
## Summary
- add a simple questionary-based TUI under `playlistgen.gui`
- expose the GUI via the CLI command `gui`
- document the new command in the README
- include questionary as a dependency
- test the GUI logic with mocked prompts

## Testing
- `pip install -q questionary>=1.10`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407137060083339542df43049aab8c