### PR TITLE
Improve playlist naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,11 @@ TRACKS_PER_MIX: 50
 YEAR_MIX_ENABLED: true
 YEAR_MIX_RANGE: 1
 CACHE_DB: ~/.playlistgen/mood_cache.sqlite
+SPOTIFY_REDIRECT_URI: http://localhost:8888/callback
 ```
+
+The `SPOTIFY_REDIRECT_URI` value must match one of the redirect URIs
+configured in your Spotify developer dashboard.
 
 To use online genre/mood detection, set your **Last.fm API key** in the config.
 
@@ -127,7 +131,7 @@ To use online genre/mood detection, set your **Last.fm API key** in the config.
 3. **Genre Recovery:** Fill missing genres using Last.fm tags.
 4. **Track Scoring:** Apply custom scoring using plays, skips, artist and year affinity.
 5. **Clustering:** TF-IDF clustering by artist, genre, and track name.
-6. **Mix Creation:** Build year-based mixes (optional) and cluster-based mixes named by top genres.
+6. **Mix Creation:** Build year-based mixes (optional) and cluster-based mixes named with human-friendly mood and genre labels.
 7. **M3U Export:** Save playlists into the `./mixes` folder.
 
 ---

--- a/playlistgen/clustering.py
+++ b/playlistgen/clustering.py
@@ -17,20 +17,43 @@ except ImportError:
     HDBSCAN_AVAILABLE = False
 
 
+MOOD_ADJECTIVES = {
+    "Happy": "Joyful",
+    "Sad": "Melancholic",
+    "Angry": "Fiery",
+    "Chill": "Chill",
+    "Energetic": "Energetic",
+    "Romantic": "Romantic",
+    "Epic": "Epic",
+    "Dreamy": "Dreamy",
+    "Groovy": "Groovy",
+    "Nostalgic": "Nostalgic",
+}
+
+
+def humanize_label(mood: str | None, genre: str | None) -> str:
+    """Return a more natural playlist label from mood/genre."""
+    mood_adj = MOOD_ADJECTIVES.get(mood, mood) if mood else None
+    if mood_adj and genre:
+        return f"{mood_adj} {genre}"
+    if genre:
+        return genre
+    if mood_adj:
+        return mood_adj
+    return "Mix"
+
+
 def name_cluster(df=None, i=None):
-    """
-    Generate a descriptive name for a cluster based on its top mood and genre.
-    """
-    parts = []
+    """Generate a descriptive name for a cluster based on its top mood and genre."""
+    mood = None
+    genre = None
     if df is not None:
         if "Mood" in df.columns and df["Mood"].notnull().any():
-            top_mood = df["Mood"].mode().iloc[0]
-            parts.append(top_mood)
+            mood = df["Mood"].mode().iloc[0]
         if "Genre" in df.columns and df["Genre"].notnull().any():
-            top_genre = df["Genre"].mode().iloc[0]
-            parts.append(top_genre)
-    if parts:
-        return " & ".join(parts) + " Mix"
+            genre = df["Genre"].mode().iloc[0]
+    if mood or genre:
+        return humanize_label(mood, genre)
     if i is not None:
         return f"Cluster {i + 1}"
     return "Cluster"

--- a/playlistgen/config.py
+++ b/playlistgen/config.py
@@ -36,6 +36,8 @@ def load_config(path: str = None) -> dict:
         # Add this line to set a default mood cache path
         "TAG_MOOD_CACHE": str(Path.home() / ".playlistgen" / "lastfm_tags_cache.json"),
         "CACHE_DB": str(Path.home() / ".playlistgen" / "mood_cache.sqlite"),
+        # Default Spotify OAuth redirect URI
+        "SPOTIFY_REDIRECT_URI": "http://localhost:8888/callback",
     }
 
     # Determine where to load the user config: explicit path, project-root config.yml, or home config

--- a/playlistgen/gui.py
+++ b/playlistgen/gui.py
@@ -41,7 +41,7 @@ def spotify_login(cfg: dict) -> None:
             client_id=cfg.get("SPOTIFY_CLIENT_ID"),
             client_secret=cfg.get("SPOTIFY_CLIENT_SECRET"),
             scope="playlist-modify-private",
-            redirect_uri="http://localhost:8888/callback",
+            redirect_uri=cfg.get("SPOTIFY_REDIRECT_URI", "http://localhost:8888/callback"),
         )
         token = auth.get_access_token(as_dict=False)
         cfg["SPOTIFY_TOKEN"] = token

--- a/playlistgen/pipeline.py
+++ b/playlistgen/pipeline.py
@@ -11,7 +11,7 @@ from .itunes import (
 from .tag_mood_service import generate_tag_mood_cache, load_tag_mood_db
 from .spotify_profile import build_profile, load_profile
 from .scoring import score_tracks
-from .clustering import cluster_tracks, name_cluster
+from .clustering import cluster_tracks, name_cluster, humanize_label
 from .playlist_builder import build_playlists
 
 
@@ -80,12 +80,7 @@ def run_pipeline(cfg, genre=None, mood=None, library_dir=None):
             logging.warning(f"No tracks found matching genre={genre!r} mood={mood!r}")
             return
 
-        parts = []
-        if mood:
-            parts.append(mood)
-        if genre:
-            parts.append(genre)
-        label = " & ".join(parts) + " Mix"
+        label = humanize_label(mood, genre)
         build_playlists([filt_df], scored_df, name_fn=lambda *_: label)
         return
 

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,2 +1,15 @@
-def test_clustering_stub():
-    assert True
+import pandas as pd
+from playlistgen.clustering import name_cluster, humanize_label
+
+
+def test_humanize_label_basic():
+    assert humanize_label("Sad", "Country") == "Melancholic Country"
+    assert humanize_label("Happy", None) == "Joyful"
+    assert humanize_label(None, "Rock") == "Rock"
+
+
+def test_name_cluster_human_order():
+    df = pd.DataFrame({"Mood": ["Sad", "Sad"], "Genre": ["Country", "Country"]})
+    assert name_cluster(df) == "Melancholic Country"
+
+


### PR DESCRIPTION
## Summary
- humanize cluster names using mood adjectives before genre
- update pipeline label generation to use new function
- clarify naming step in README
- add tests covering new naming logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840a0f7ae4c8333a0d9314ae9368b3a