### PR TITLE
Fix batch enrichment truncation: raise max_tokens from 2048 to 8192

### DIFF
--- a/playlistgen/ai_enhancer.py
+++ b/playlistgen/ai_enhancer.py
@@ -410,7 +410,7 @@ def batch_enrich_metadata(
             try:
                 message = client.messages.create(
                     model=model,
-                    max_tokens=2048,
+                    max_tokens=8192,
                     system=_ENRICH_SYSTEM,
                     messages=[{"role": "user", "content": user_msg}],
                 )


### PR DESCRIPTION
150-track batches require ~3750+ output tokens; the previous 2048 limit caused Claude to truncate the JSON response mid-array, producing repeated parse errors on every batch.